### PR TITLE
Update DraggableGui.js

### DIFF
--- a/shared/DraggableGui.js
+++ b/shared/DraggableGui.js
@@ -71,9 +71,7 @@ export default class DraggableGui {
     setCommandName(name) {
         this.commandName = name
 
-        register("command", () => {
-            this.ctGui.open()
-        }).setName(name)
+        addCommand(name, `Opens single editor for ${this.featureName}`, () => this.ctGui.open())
 
         return this
     }

--- a/shared/TextHelper.js
+++ b/shared/TextHelper.js
@@ -174,7 +174,7 @@ export class TextHelper {
     static convertToNumber(string) {
         if (!/^([\d.,]+)([A-z]+)$/.test(string)) return parseFloat(string.replace(/,/g, ""))
 
-        const [ _, number, format ] = string.match(/^([\d.,]+)([A-z]+)$/)
+        const [ _, number, format ] = string.match(/^([\d\.,]+)([A-z]+)$/)
 
         return parseFloat(number) * numberFormat[format]
     }


### PR DESCRIPTION
Changes command in DraggableGui.setCommandName() to use addCommand
* In special case of main editor gui not working or buttons not registering being clicked on, this may help users know how to move guis

Fix convertToNumber regex matching all characters "." instead of just periods "\."